### PR TITLE
GOD-17-card-pile-view

### DIFF
--- a/scenes/battle/battle.gd
+++ b/scenes/battle/battle.gd
@@ -22,6 +22,7 @@ func _ready() -> void:
 	Events.player_died.connect(_on_player_died)
 	
 	start_battle(new_stats)
+	battle_ui.initialize_card_pile_ui()
 	
 
 func start_battle(stats: CharacterStats) -> void:

--- a/scenes/battle/battle.tscn
+++ b/scenes/battle/battle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=3 uid="uid://dnxcetmr0mf87"]
+[gd_scene load_steps=23 format=3 uid="uid://dnxcetmr0mf87"]
 
 [ext_resource type="Texture2D" uid="uid://cp4iq5fd6j8be" path="res://art/background.png" id="1_44336"]
 [ext_resource type="Script" path="res://scenes/battle/battle.gd" id="1_gln7b"]
@@ -18,6 +18,9 @@
 [ext_resource type="Theme" uid="uid://dgqcqnibgqgom" path="res://main_theme.tres" id="13_rceg3"]
 [ext_resource type="Script" path="res://scenes/ui/red_flash.gd" id="15_748cc"]
 [ext_resource type="PackedScene" uid="uid://gnf2kjm05v67" path="res://scenes/ui/battle_over_panel.tscn" id="17_37ygh"]
+[ext_resource type="PackedScene" uid="uid://glgshreghmbo" path="res://scenes/ui/card_pile_opener.tscn" id="17_gn7hq"]
+[ext_resource type="Texture2D" uid="uid://dtghabcnnuxsc" path="res://art/discard.png" id="18_o2uky"]
+[ext_resource type="PackedScene" uid="uid://cd72g2tvg6pm5" path="res://scenes/ui/card_pile_view.tscn" id="21_afai6"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_w514v"]
 size = Vector2(256, 100)
@@ -85,6 +88,8 @@ alignment = 1
 script = ExtResource("2_8if04")
 
 [node name="ManaUI" parent="BattleUI" instance=ExtResource("11_05usk")]
+offset_top = -40.0
+offset_bottom = -22.0
 char_stats = ExtResource("4_q7bun")
 
 [node name="Tooltip" parent="BattleUI" instance=ExtResource("12_1xhed")]
@@ -99,13 +104,59 @@ anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -50.0
-offset_top = -20.0
+offset_top = -37.0
 offset_right = -5.0
-offset_bottom = -6.0
+offset_bottom = -23.0
 grow_horizontal = 0
 grow_vertical = 0
 theme = ExtResource("13_rceg3")
 text = "End Turn"
+
+[node name="DrawPileButton" parent="BattleUI" node_paths=PackedStringArray("counter") instance=ExtResource("17_gn7hq")]
+unique_name_in_owner = true
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 6.0
+offset_top = -20.0
+offset_right = 22.0
+offset_bottom = -4.0
+grow_vertical = 0
+counter = NodePath("Counter")
+
+[node name="Counter" type="Label" parent="BattleUI/DrawPileButton"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 12.0
+offset_right = 20.0
+offset_bottom = 18.0
+text = "99"
+horizontal_alignment = 1
+
+[node name="DiscardPileButton" parent="BattleUI" node_paths=PackedStringArray("counter") instance=ExtResource("17_gn7hq")]
+unique_name_in_owner = true
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -23.0
+offset_top = -20.0
+offset_right = -7.0
+offset_bottom = -4.0
+grow_horizontal = 0
+grow_vertical = 0
+texture_normal = ExtResource("18_o2uky")
+counter = NodePath("Counter")
+
+[node name="Counter" type="Label" parent="BattleUI/DiscardPileButton"]
+layout_mode = 0
+offset_left = -3.0
+offset_top = 12.0
+offset_right = 7.0
+offset_bottom = 18.0
+text = "99"
+horizontal_alignment = 1
 
 [node name="RedFlash" type="CanvasLayer" parent="."]
 layer = 2
@@ -125,7 +176,18 @@ wait_time = 0.1
 one_shot = true
 
 [node name="BattleOverLayer" type="CanvasLayer" parent="."]
-layer = 2
+layer = 5
 
 [node name="BattleOverPanel" parent="BattleOverLayer" instance=ExtResource("17_37ygh")]
+visible = false
+
+[node name="CardPileViews" type="CanvasLayer" parent="."]
+layer = 4
+
+[node name="DrawPileView" parent="CardPileViews" instance=ExtResource("21_afai6")]
+unique_name_in_owner = true
+visible = false
+
+[node name="DiscardPileView" parent="CardPileViews" instance=ExtResource("21_afai6")]
+unique_name_in_owner = true
 visible = false

--- a/scenes/run/run.gd
+++ b/scenes/run/run.gd
@@ -11,6 +11,9 @@ const TREASURE_SCENE = preload("res://scenes/treasure/treasure.tscn")
 @export var run_startup: RunStartup
 
 @onready var current_view: Node = $CurrentView
+@onready var deck_button: CardPileOpener = %DeckButton
+@onready var deck_view: CardPileView = %DeckView
+
 @onready var battle_button: Button = %BattleButton
 @onready var campfire_button: Button = %CampfireButton
 @onready var map_button: Button = %MapButton
@@ -35,6 +38,7 @@ func _ready() -> void:
 
 func _start_run() -> void:
 	_setup_event_connections()
+	_setup_top_bar()
 	print("TODO: procedurally generate map")
 	
 
@@ -61,6 +65,12 @@ func _setup_event_connections() -> void:
 	rewards_button.pressed.connect(_change_view.bind(BATTLE_REWARD_SCENE))
 	shop_button.pressed.connect(_change_view.bind(SHOP_SCENE))
 	treasure_button.pressed.connect(_change_view.bind(TREASURE_SCENE))
+	
+
+func _setup_top_bar() -> void:
+	deck_button.card_pile = character.deck
+	deck_view.card_pile = character.deck
+	deck_button.pressed.connect(deck_view.show_current_view.bind("Deck"))
 	
 
 func _on_map_exited() -> void:

--- a/scenes/run/run.tscn
+++ b/scenes/run/run.tscn
@@ -1,8 +1,11 @@
-[gd_scene load_steps=4 format=3 uid="uid://dsiwop5yyta0y"]
+[gd_scene load_steps=7 format=3 uid="uid://dsiwop5yyta0y"]
 
 [ext_resource type="Script" path="res://scenes/run/run.gd" id="1_dplcj"]
 [ext_resource type="PackedScene" uid="uid://b03nhgouu83pk" path="res://scenes/map/map.tscn" id="1_khr5v"]
 [ext_resource type="Resource" uid="uid://c5wyqv8h0hxr" path="res://scenes/run/run_startup.tres" id="2_o8q7h"]
+[ext_resource type="PackedScene" uid="uid://glgshreghmbo" path="res://scenes/ui/card_pile_opener.tscn" id="4_r7aqa"]
+[ext_resource type="Texture2D" uid="uid://d3tqm8jwnmyeq" path="res://art/deck.png" id="5_q41ws"]
+[ext_resource type="PackedScene" uid="uid://cd72g2tvg6pm5" path="res://scenes/ui/card_pile_view.tscn" id="6_hm6h4"]
 
 [node name="Run" type="Node"]
 script = ExtResource("1_dplcj")
@@ -16,6 +19,7 @@ run_startup = ExtResource("2_o8q7h")
 anchors_preset = 9
 anchor_bottom = 1.0
 grow_vertical = 2
+alignment = 1
 
 [node name="MapButton" type="Button" parent="DebugButtons"]
 unique_name_in_owner = true
@@ -46,3 +50,43 @@ text = "Rewards"
 unique_name_in_owner = true
 layout_mode = 2
 text = "Campfire"
+
+[node name="TopBar" type="CanvasLayer" parent="."]
+layer = 3
+
+[node name="Background" type="ColorRect" parent="TopBar"]
+custom_minimum_size = Vector2(0, 18)
+anchors_preset = 10
+anchor_right = 1.0
+grow_horizontal = 2
+color = Color(0.0352941, 0.0196078, 0, 0.623529)
+
+[node name="BarItems" type="HBoxContainer" parent="TopBar"]
+custom_minimum_size = Vector2(0, 18)
+anchors_preset = 10
+anchor_right = 1.0
+grow_horizontal = 2
+
+[node name="Placeholder" type="Control" parent="TopBar/BarItems"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="DeckButton" parent="TopBar/BarItems" node_paths=PackedStringArray("counter") instance=ExtResource("4_r7aqa")]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(16, 16)
+layout_mode = 2
+texture_normal = ExtResource("5_q41ws")
+counter = NodePath("Counter")
+
+[node name="Counter" type="Label" parent="TopBar/BarItems/DeckButton"]
+layout_mode = 0
+offset_left = -5.0
+offset_top = 12.0
+offset_right = 5.0
+offset_bottom = 18.0
+text = "99"
+horizontal_alignment = 1
+
+[node name="DeckView" parent="TopBar" instance=ExtResource("6_hm6h4")]
+unique_name_in_owner = true
+visible = false

--- a/scenes/run/run_startup.tres
+++ b/scenes/run/run_startup.tres
@@ -1,7 +1,9 @@
-[gd_resource type="Resource" script_class="RunStartup" load_steps=2 format=3 uid="uid://c5wyqv8h0hxr"]
+[gd_resource type="Resource" script_class="RunStartup" load_steps=3 format=3 uid="uid://c5wyqv8h0hxr"]
 
 [ext_resource type="Script" path="res://custom_resources/run_startup.gd" id="1_os3dl"]
+[ext_resource type="Resource" uid="uid://bsibnsrqm7jh2" path="res://characters/warrior/warrior.tres" id="1_y3wuy"]
 
 [resource]
 script = ExtResource("1_os3dl")
 type = 0
+picked_character = ExtResource("1_y3wuy")

--- a/scenes/ui/battle_ui.gd
+++ b/scenes/ui/battle_ui.gd
@@ -3,26 +3,40 @@ extends CanvasLayer
 
 @export var char_stats: CharacterStats : set = _set_char_stats
 
-@onready var hand: Hand = $Hand as Hand
-@onready var mana_ui: ManaUI = $ManaUI as ManaUI
+@onready var hand: Hand = $Hand
+@onready var mana_ui: ManaUI = $ManaUI
 @onready var end_turn_button: Button = %EndTurnButton
+@onready var draw_pile_button: CardPileOpener = %DrawPileButton
+@onready var discard_pile_button: CardPileOpener = %DiscardPileButton
+@onready var draw_pile_view: CardPileView = %DrawPileView
+@onready var discard_pile_view: CardPileView = %DiscardPileView
 
 
 func _ready() -> void:
 	Events.player_hand_drawn.connect(_on_player_hand_drawn)
 	end_turn_button.pressed.connect(_on_end_turn_button_pressed)
+	draw_pile_button.pressed.connect(draw_pile_view.show_current_view.bind("Draw Pile", true))
+	discard_pile_button.pressed.connect(discard_pile_view.show_current_view.bind("Discard Pile"))
+	
 
+func initialize_card_pile_ui() -> void:
+	draw_pile_button.card_pile = char_stats.draw_pile
+	draw_pile_view.card_pile = char_stats.draw_pile
+	discard_pile_button.card_pile = char_stats.discard
+	discard_pile_view.card_pile = char_stats.discard
+	
 
 func _set_char_stats(value: CharacterStats) -> void:
 	char_stats = value
 	mana_ui.char_stats = char_stats
 	hand.char_stats = char_stats
-
+	
 
 func _on_player_hand_drawn() -> void:
 	end_turn_button.disabled = false
-
+	
 
 func _on_end_turn_button_pressed() -> void:
 	end_turn_button.disabled = true
 	Events.player_turn_ended.emit()
+	

--- a/scenes/ui/card_menu_ui.gd
+++ b/scenes/ui/card_menu_ui.gd
@@ -1,0 +1,35 @@
+class_name CardMenuUI
+extends CenterContainer
+
+signal tooltip_requested(card: Card)
+
+const BASE_STYLEBOX := preload("res://scenes/card_ui/card_base_stylebox.tres")
+const HOVER_STYLEBOX := preload("res://scenes/card_ui/card_hover_stylebox.tres")
+
+@export var card: Card : set = set_card
+
+@onready var panel: Panel = $Visuals/Panel
+@onready var cost: Label = $Visuals/Cost
+@onready var icon: TextureRect = $Visuals/Icon
+
+
+func _on_visuals_gui_input(event: InputEvent) -> void:
+	if event.is_action_pressed("left_mouse"):
+		tooltip_requested.emit(card)
+	
+
+func _on_visuals_mouse_entered() -> void:
+	panel.set("theme_override_styles/panel", HOVER_STYLEBOX)
+	
+
+func _on_visuals_mouse_exited() -> void:
+	panel.set("theme_override_styles/panel", BASE_STYLEBOX)
+	
+
+func set_card(value: Card) -> void:
+	if not is_node_ready():
+		await ready
+	
+	card = value
+	cost.text = str(card.cost)
+	icon.texture = card.icon

--- a/scenes/ui/card_menu_ui.tscn
+++ b/scenes/ui/card_menu_ui.tscn
@@ -1,0 +1,59 @@
+[gd_scene load_steps=6 format=3 uid="uid://brd3tssb21yx3"]
+
+[ext_resource type="Script" path="res://scenes/ui/card_menu_ui.gd" id="1_ugm4d"]
+[ext_resource type="Resource" uid="uid://dqsd847blmhjl" path="res://characters/warrior/cards/warrior_slash.tres" id="2_heory"]
+[ext_resource type="Theme" uid="uid://dgqcqnibgqgom" path="res://main_theme.tres" id="3_82ijs"]
+[ext_resource type="StyleBox" uid="uid://b7hr7qei7ts41" path="res://scenes/card_ui/card_base_stylebox.tres" id="3_p586d"]
+[ext_resource type="Texture2D" uid="uid://c6rme2o6dyaoj" path="res://art/tile_0104.png" id="4_ryurn"]
+
+[node name="CardMenuUI" type="CenterContainer"]
+offset_right = 25.0
+offset_bottom = 30.0
+size_flags_horizontal = 3
+script = ExtResource("1_ugm4d")
+card = ExtResource("2_heory")
+
+[node name="Visuals" type="Control" parent="."]
+custom_minimum_size = Vector2(25, 30)
+layout_mode = 2
+
+[node name="Panel" type="Panel" parent="Visuals"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+theme_override_styles/panel = ExtResource("3_p586d")
+
+[node name="Cost" type="Label" parent="Visuals"]
+layout_mode = 1
+offset_right = 10.0
+offset_bottom = 10.0
+theme = ExtResource("3_82ijs")
+text = "2"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Icon" type="TextureRect" parent="Visuals"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -5.0
+offset_top = -5.0
+offset_right = 5.0
+offset_bottom = 5.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+texture = ExtResource("4_ryurn")
+expand_mode = 1
+stretch_mode = 5
+
+[connection signal="gui_input" from="Visuals" to="." method="_on_visuals_gui_input"]
+[connection signal="mouse_entered" from="Visuals" to="." method="_on_visuals_mouse_entered"]
+[connection signal="mouse_exited" from="Visuals" to="." method="_on_visuals_mouse_exited"]

--- a/scenes/ui/card_pile_opener.gd
+++ b/scenes/ui/card_pile_opener.gd
@@ -1,0 +1,18 @@
+class_name CardPileOpener
+extends TextureButton
+
+@export var counter: Label
+@export var card_pile: CardPile : set = set_card_pile
+
+
+func set_card_pile(new_value: CardPile) -> void:
+	card_pile = new_value
+	
+	if not card_pile.card_pile_size_changed.is_connected(_on_card_pile_size_changed):
+		card_pile.card_pile_size_changed.connect(_on_card_pile_size_changed)
+		_on_card_pile_size_changed(card_pile.cards.size())
+	
+
+func _on_card_pile_size_changed(cards_amount: int) -> void:
+	counter.text = str(cards_amount)
+	

--- a/scenes/ui/card_pile_opener.tscn
+++ b/scenes/ui/card_pile_opener.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=3 uid="uid://glgshreghmbo"]
+
+[ext_resource type="Texture2D" uid="uid://c6feqj3jhaavj" path="res://art/draw.png" id="1_ms4xx"]
+[ext_resource type="Script" path="res://scenes/ui/card_pile_opener.gd" id="2_44gwm"]
+
+[node name="CardPileOpener" type="TextureButton"]
+offset_right = 16.0
+offset_bottom = 16.0
+texture_normal = ExtResource("1_ms4xx")
+ignore_texture_size = true
+stretch_mode = 5
+script = ExtResource("2_44gwm")

--- a/scenes/ui/card_pile_view.gd
+++ b/scenes/ui/card_pile_view.gd
@@ -1,0 +1,54 @@
+class_name CardPileView
+extends Control
+
+const CARD_MENU_UI_SCENE := preload("res://scenes/ui/card_menu_ui.tscn")
+
+@export var card_pile: CardPile
+
+@onready var title: Label = %Title
+@onready var cards: GridContainer = %Cards
+@onready var card_tooltip_popup: CardTooltipPopup = %CardTooltipPopup
+@onready var back_button: Button = %BackButton
+
+func _ready() -> void:
+	back_button.pressed.connect(hide)
+	
+	for card: Node in cards.get_children():
+		card.queue_free()
+	
+	card_tooltip_popup.hide_tooltip()
+	
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		if card_tooltip_popup.visible:
+			card_tooltip_popup.hide_tooltip()
+		else:
+			hide()
+	
+
+func show_current_view(new_title: String, randomized: bool = false) -> void:
+	for card: Node in cards.get_children():
+		card.queue_free()
+	
+	card_tooltip_popup.hide_tooltip()
+	title.text = new_title
+	_update_view.call_deferred(randomized)
+	
+
+func _update_view(randomized: bool) -> void:
+	if not card_pile:
+		return
+	
+	var all_cards := card_pile.cards.duplicate()
+	if randomized:
+		all_cards.shuffle()
+	
+	for card: Card in all_cards:
+		var new_card := CARD_MENU_UI_SCENE.instantiate() as CardMenuUI
+		cards.add_child(new_card)
+		new_card.card = card
+		new_card.tooltip_requested.connect(card_tooltip_popup.show_tooltip)
+	
+	show()
+	

--- a/scenes/ui/card_pile_view.tscn
+++ b/scenes/ui/card_pile_view.tscn
@@ -1,0 +1,156 @@
+[gd_scene load_steps=5 format=3 uid="uid://cd72g2tvg6pm5"]
+
+[ext_resource type="PackedScene" uid="uid://brd3tssb21yx3" path="res://scenes/ui/card_menu_ui.tscn" id="1_23ha3"]
+[ext_resource type="Script" path="res://scenes/ui/card_pile_view.gd" id="1_kbolj"]
+[ext_resource type="PackedScene" uid="uid://c04vinj2b5q1h" path="res://scenes/ui/card_tooltip_popup.tscn" id="3_frqv2"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_0ucht"]
+font_size = 12
+
+[node name="CardPileView" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_kbolj")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.0980392, 0.0117647, 0.0431373, 0.639216)
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="Title" type="Label" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Discard Pile"
+label_settings = SubResource("LabelSettings_0ucht")
+horizontal_alignment = 1
+
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+horizontal_scroll_mode = 3
+vertical_scroll_mode = 2
+
+[node name="Cards" type="GridContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/h_separation = 0
+theme_override_constants/v_separation = 5
+columns = 6
+
+[node name="CardMenuUI" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI2" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI3" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI4" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI5" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI6" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI7" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI8" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI9" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI10" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI11" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI12" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI13" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI15" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI16" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI17" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI18" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI19" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI20" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI21" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI22" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI23" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI24" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI25" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI26" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="CardMenuUI14" parent="MarginContainer/VBoxContainer/ScrollContainer/Cards" instance=ExtResource("1_23ha3")]
+layout_mode = 2
+
+[node name="BackButton" type="Button" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 208.0
+offset_top = 8.0
+offset_right = 248.0
+offset_bottom = 22.0
+text = "Back"
+
+[node name="CardTooltipPopup" parent="." instance=ExtResource("3_frqv2")]
+unique_name_in_owner = true
+visible = false
+layout_mode = 1

--- a/scenes/ui/card_tooltip_popup.gd
+++ b/scenes/ui/card_tooltip_popup.gd
@@ -1,0 +1,37 @@
+class_name CardTooltipPopup
+extends Control
+
+const CARD_MENU_UI_SCENE := preload("res://scenes/ui/card_menu_ui.tscn")
+
+@onready var tooltip_card: CenterContainer = %TooltipCard
+@onready var card_description: RichTextLabel = %CardDescription
+
+
+func _ready() -> void:
+	for card: CardMenuUI in tooltip_card.get_children():
+		card.queue_free()
+	
+
+func show_tooltip(card: Card) -> void:
+	var new_card := CARD_MENU_UI_SCENE.instantiate() as CardMenuUI
+	tooltip_card.add_child(new_card)
+	new_card.card = card
+	new_card.tooltip_requested.connect(hide_tooltip.unbind(1))
+	card_description.text = card.tooltip_text
+	show()
+	
+
+func hide_tooltip() -> void:
+	if not visible:
+		return
+	
+	for card: CardMenuUI in tooltip_card.get_children():
+		card.queue_free()
+	
+	hide()
+	
+
+func _on_gui_input(event: InputEvent) -> void:
+	if event.is_action_pressed("left_mouse"):
+		hide_tooltip()
+		

--- a/scenes/ui/card_tooltip_popup.tscn
+++ b/scenes/ui/card_tooltip_popup.tscn
@@ -1,0 +1,56 @@
+[gd_scene load_steps=3 format=3 uid="uid://c04vinj2b5q1h"]
+
+[ext_resource type="PackedScene" uid="uid://brd3tssb21yx3" path="res://scenes/ui/card_menu_ui.tscn" id="1_getrt"]
+[ext_resource type="Script" path="res://scenes/ui/card_tooltip_popup.gd" id="1_ym2lj"]
+
+[node name="CardTooltipPopup" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_ym2lj")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+color = Color(0, 0, 0, 0.776471)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -75.0
+offset_top = -26.0
+offset_right = 75.0
+offset_bottom = 26.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="TooltipCard" type="CenterContainer" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="CardMenuUI" parent="VBoxContainer/TooltipCard" instance=ExtResource("1_getrt")]
+layout_mode = 2
+
+[node name="CardDescription" type="RichTextLabel" parent="VBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+mouse_filter = 2
+bbcode_enabled = true
+text = "Card Description Card Description Card Description Card Description
+Card Description Card Description"
+fit_content = true
+
+[connection signal="gui_input" from="." to="." method="_on_gui_input"]


### PR DESCRIPTION
- add `card_pile_view` scenes
- this is used 3 times: to view the full deck, view the current draw pile and the current discard pile
- create UI to display and change dynamically for changes
- add tooltip scenes to show when pressing a card in the card pile view